### PR TITLE
Remove staggered project card entrance animation

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -3,17 +3,9 @@ import path from "path";
 import matter from "gray-matter";
 import Head from "next/head";
 import ProjectCard from "../components/ProjectCard";
-import { motion } from "framer-motion";
 import Image from "next/image";
 import TimelineItem from "../components/TimelineItem";
 import { getAssetUrl } from "../lib/assets";
-
-const projectCardSpring = {
-    type: 'spring',
-    stiffness: 120,
-    damping: 42,
-    mass: 2.1,
-};
 
 export default function Home({ projects }) {
     const heroCtaCell =
@@ -172,23 +164,13 @@ export default function Home({ projects }) {
                         <h2 className="text-2xl text-gray-900 dark:text-white">Projects</h2>
                     </div>
                     <div className="mb-6 flex flex-col divide-y divide-gray-200 dark:divide-gray-800 border-y border-gray-200 dark:border-gray-800">
-                        {(projects || []).map((project, index) => (
-                            <motion.div
+                        {(projects || []).map((project) => (
+                            <ProjectCard
                                 key={project.id}
-                                initial={{ opacity: 0, y: 36 }}
-                                whileInView={{ opacity: 1, y: 0 }}
-                                viewport={{ once: true, amount: 0.2, margin: '0px 0px -10% 0px' }}
-                                transition={{
-                                    ...projectCardSpring,
-                                    delay: index * 0.12,
-                                }}
-                            >
-                                <ProjectCard
-                                    project={project}
-                                    showTechnologies={false}
-                                    showImagePreview={false}
-                                />
-                            </motion.div>
+                                project={project}
+                                showTechnologies={false}
+                                showImagePreview={false}
+                            />
                         ))}
                     </div>
                 </section>


### PR DESCRIPTION
## Summary
- Project cards on the homepage now render immediately instead of fading in one-by-one on scroll
- Removes the `motion.div` wrapper, `whileInView` trigger, and `projectCardSpring` config
- Drops the now-unused `framer-motion` import from `src/pages/index.js`

## Why
The per-index delay (up to ~1.2s for later cards) felt sluggish on first paint — users scrolled past the list before it finished animating in.

## Test plan
- [x] `pnpm dev` and confirm project cards appear instantly on homepage load
- [x] Scroll past and back — no re-animation, no layout shift
- [ ] `pnpm lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)